### PR TITLE
monitor jenkins processes

### DIFF
--- a/monitor_resources.sh
+++ b/monitor_resources.sh
@@ -1,7 +1,7 @@
 FILE=memory-usage-log.txt
 while true;
     do
-        ps eo pid,%cpu,%mem,args,uname --sort=-%mem >> $FILE;
+        ps -u jenkins eo pid,%cpu,%mem,args,uname --sort=-%mem >> $FILE;
         echo "----------" >> $FILE;
         sleep 1;
     done


### PR DESCRIPTION
Without the argument no processes are logged.
We need to monitor all processes of user jenkins.