### PR TITLE
Changed script to log all processes

### DIFF
--- a/monitor_resources.sh
+++ b/monitor_resources.sh
@@ -1,7 +1,8 @@
 FILE=memory-usage-log.txt
+MAX_PROCESSES=11 #amount of processes to show +1 (Header line)
 while true;
     do
-        ps -u jenkins eo pid,%cpu,%mem,args,uname --sort=-%mem >> $FILE;
-        echo "----------" >> $FILE;
-        sleep 1;
+        ps -e eo pid,%cpu,%mem,uname,args --sort=-%mem | head -n $MAX_PROCESSES >> $FILE
+        echo "----------------------------------------------" >> $FILE;
+        sleep 5;
     done


### PR DESCRIPTION
I changed the process listing from one, to all user. Now it's possible to detect memory consumption, even outside the user's scope.
I also changed the order of the columns, to prevent ps from cutting the command section. 
Also i changed the sleeping time to 5. That should reduce the log file size and is still more exact then we need.